### PR TITLE
release: v1.0.1

### DIFF
--- a/components/ContributionGraph.tsx
+++ b/components/ContributionGraph.tsx
@@ -26,13 +26,13 @@ export default function ContributionGraph({ data }: { data: Contributions }) {
           <span className="text-muted"> active days in the last year</span>
         </span>
       </div>
-      <div className="mt-3 overflow-x-auto">
+      <div className="mt-3 max-w-[720px] overflow-x-auto">
         <svg
           role="img"
           aria-label={`GitHub contribution heatmap — ${data.totalYear} contributions in the last year, including private repositories`}
-          width={width}
-          height={height}
-          className="block"
+          viewBox={`0 0 ${width} ${height}`}
+          preserveAspectRatio="xMidYMid meet"
+          className="block w-full h-auto"
         >
           {data.weeks.map((week, wi) =>
             week.map((day) => {

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -31,18 +31,18 @@ export default function Hero({
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-12 items-start mt-6 relative">
         <div className="lg:col-span-5 flex flex-col">
           <h1
-            className="font-mono font-medium text-[28px] md:text-[36px] lg:text-[40px]"
+            className="font-mono font-medium text-[28px] md:text-[40px] lg:text-[52px] xl:text-[60px] 2xl:text-[68px]"
             style={{
               letterSpacing: "-0.5px",
-              lineHeight: 1.25,
-              maxWidth: 520,
+              lineHeight: 1.15,
+              maxWidth: "18ch",
             }}
           >
             I build software that actually ships.
           </h1>
           <p
-            className="font-sans text-[15px] text-muted mt-5"
-            style={{ lineHeight: 1.6, maxWidth: 480 }}
+            className="font-sans text-[15px] md:text-[16px] lg:text-[17px] xl:text-[18px] text-muted mt-5"
+            style={{ lineHeight: 1.6, maxWidth: "44ch" }}
           >
             Using AI to drive revenue-multiplying outcomes for founders and
             small teams.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iwrightcode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iwrightcode",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iwrightcode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.0.1

Small UI polish pass.

### Fixes
- `fix(ui)` scale hero headline + contribution graph responsively (19df197)
  - Hero h1 now grows through md/lg/xl/2xl instead of plateauing at 40px
  - Contribution graph scales down with viewport instead of demanding a horizontal scrollbar
- `chore(release)` bump to v1.0.1 (5907108)

### Pre-flight
- [x] Lint clean
- [x] Typecheck clean
- [x] Reviewer pass
- [x] No blocking issues

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.ai/claude-code)