### PR TITLE
feat(seo): foundational SEO and LLM visibility

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,22 +17,129 @@ const inter = Inter({
   weight: ["400", "500"],
 });
 
+const SITE_URL = "https://iwrightcode.com";
+const SITE_NAME = "iwrightcode_";
+const TITLE = "iwrightcode_ — Isaac Wright, full-stack developer";
+const DESCRIPTION =
+  "Using AI to drive revenue-multiplying outcomes for founders and small teams. Custom software, AI-native delivery, financial-services domain fluency.";
+
 export const metadata: Metadata = {
-  metadataBase: new URL("https://iwrightcode.com"),
-  title: "iwrightcode_ — Isaac Wright, full-stack developer",
-  description:
-    "Using AI to drive revenue-multiplying outcomes for founders and small teams.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: TITLE,
+    template: "%s · iwrightcode_",
+  },
+  description: DESCRIPTION,
+  applicationName: SITE_NAME,
+  authors: [{ name: "Isaac Wright", url: SITE_URL }],
+  creator: "Isaac Wright",
+  publisher: "Isaac Wright",
+  keywords: [
+    "Isaac Wright",
+    "iwrightcode",
+    "full-stack developer",
+    "AI developer",
+    "Next.js",
+    "TypeScript",
+    "Claude Code",
+    "Anthropic",
+    "Supabase",
+    "fractional CTO",
+    "contract software development",
+    "financial services software",
+    "insurance commission tracking",
+  ],
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
-    title: "iwrightcode_",
-    description: "build. ship. repeat.",
-    url: "https://iwrightcode.com",
-    siteName: "iwrightcode_",
     type: "website",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: TITLE,
+    description: DESCRIPTION,
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-snippet": -1,
+      "max-image-preview": "large",
+      "max-video-preview": -1,
+    },
   },
   icons: {
     icon: "/favicon.svg",
   },
+  category: "technology",
 };
+
+const jsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Isaac Wright",
+    alternateName: "iwrightcode",
+    url: SITE_URL,
+    image: `${SITE_URL}/opengraph-image`,
+    email: "mailto:iwrightcode@gmail.com",
+    jobTitle: "Full-stack developer",
+    description: DESCRIPTION,
+    sameAs: [
+      "https://github.com/IsaacWrong",
+      "https://www.linkedin.com/company/iwrightcode",
+    ],
+    knowsAbout: [
+      "Next.js",
+      "TypeScript",
+      "React",
+      "Tailwind CSS",
+      "Claude Code",
+      "Anthropic API",
+      "Model Context Protocol",
+      "Supabase",
+      "PostgreSQL",
+      "Financial services software",
+      "Insurance technology",
+    ],
+    knowsLanguage: ["en"],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    url: SITE_URL,
+    description: DESCRIPTION,
+    inLanguage: "en-US",
+    author: {
+      "@type": "Person",
+      name: "Isaac Wright",
+      url: SITE_URL,
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "ProfessionalService",
+    name: SITE_NAME,
+    url: SITE_URL,
+    description:
+      "Custom software, AI-native delivery, and fractional technical leadership for founders and small teams.",
+    areaServed: "Worldwide",
+    provider: {
+      "@type": "Person",
+      name: "Isaac Wright",
+      url: SITE_URL,
+    },
+  },
+];
 
 export default function RootLayout({
   children,
@@ -55,6 +162,10 @@ export default function RootLayout({
         <CommandLayer />
         <BootSequence />
         <Analytics />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
       </body>
     </html>
   );

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,97 @@
+import { ImageResponse } from "next/og";
+
+export const alt =
+  "iwrightcode_ — Isaac Wright, full-stack developer building AI-driven software that ships";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px 80px",
+          background: "#0D1117",
+          color: "#E6EDF3",
+          fontFamily: "monospace",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            color: "#7D8590",
+            fontSize: 22,
+            letterSpacing: 0.5,
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 999,
+              background: "#7ee787",
+            }}
+          />
+          <span>iwrightcode.com · open to work</span>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+          <div
+            style={{
+              fontSize: 30,
+              color: "#7D8590",
+              letterSpacing: 0.5,
+            }}
+          >
+            {"// portfolio · v2026.1"}
+          </div>
+          <div
+            style={{
+              fontSize: 84,
+              fontWeight: 500,
+              lineHeight: 1.1,
+              letterSpacing: -1,
+              maxWidth: 980,
+            }}
+          >
+            I build software that actually ships.
+          </div>
+          <div
+            style={{
+              fontSize: 32,
+              color: "#7D8590",
+              maxWidth: 900,
+              lineHeight: 1.4,
+            }}
+          >
+            Using AI to drive revenue-multiplying outcomes for founders and
+            small teams.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingTop: 28,
+            borderTop: "1px solid #30363D",
+            color: "#7D8590",
+            fontSize: 22,
+          }}
+        >
+          <span style={{ color: "#E6EDF3" }}>Isaac Wright</span>
+          <span>next.js · typescript · claude · supabase</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://iwrightcode.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://iwrightcode.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/#work`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/#activity`,
+      lastModified,
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/#about`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/#contact`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,42 @@
+# iwrightcode_
+
+> Isaac Wright — full-stack developer using AI to drive revenue-multiplying outcomes for founders and small teams. Financial advisor by day, AI-driven developer by night.
+
+Isaac builds custom software for financial services firms, independent agencies, small practices, and early-stage founders. The deliverable is production code, not prototypes or slideware. Domain fluency in finance and insurance is part of what clients pay for. AI is the operating model: Claude Code, custom subagents, and MCP servers ship the bulk of production code while Isaac architects, reviews, and decides.
+
+Available for contract work and fractional technical leadership. Remote, US Eastern Time.
+
+## Contact
+
+- Email: iwrightcode@gmail.com
+- GitHub: https://github.com/IsaacWrong
+- LinkedIn: https://www.linkedin.com/company/iwrightcode
+- Site: https://iwrightcode.com
+
+## Stack
+
+- Frontend: Next.js, TypeScript, Tailwind, React
+- Backend: Node, Supabase, Postgres, Inngest
+- AI: Claude, Vercel AI SDK, Anthropic API, MCP
+- Tooling: Vercel, GitHub, Cursor, Claude Code
+
+## Selected Work
+
+- [Palm Commissions](https://pcommissions.com): Commission tracking and reconciliation for insurance agents. Upload CSV/Excel from any carrier, reconcile earnings, manage book of business. Stack: Next.js 15, Supabase, Stripe, PostHog, Sentry. Status: shipped.
+- [ExitEdge AI](https://exitedgeai.com): Marketing site and lead engine for a consulting firm helping owner-operated businesses prepare for exit through AI and process engineering. Stack: Next.js 16, Anthropic SDK, Supabase, Resend. Status: shipped.
+- [Bluegrass Home Services](https://bluegrasshservices.com): Marketing site and quote pipeline for a regional home-services company. Rate-limited quote form with direct-to-inbox delivery. Stack: Next.js 16, Resend, Upstash Redis, Zod. Status: shipped.
+- Autoform: Internal account-opening automation for a wealth management firm. Multi-step advisor intake routes through Make.com to populate DocuSign packets for client signature. Stack: Next.js 16, Zod, Make.com, DocuSign. Status: shipped.
+- Bookcheckr: AI-powered annuity book-of-business review for financial advisors. Desktop app that surfaces opportunities in under 30 seconds. Stack: Electron, React, Vite, Supabase, Anthropic, Stripe. Status: shipped.
+- Rectorfolio: Social investing platform with an AI co-pilot that creates strategies from natural language, executes trades, and explains every rebalance. Stack: Next.js 16, Vercel AI SDK, Anthropic, Supabase, Inngest. Status: building.
+
+## Engagement Model
+
+- Contract / project-based custom software builds
+- Fractional technical leadership for early-stage teams
+- Domain focus: financial services, insurance, professional services
+- AI-native delivery: short path from idea to revenue, production-grade code
+
+## Reference
+
+- Sitemap: https://iwrightcode.com/sitemap.xml
+- Robots: https://iwrightcode.com/robots.txt


### PR DESCRIPTION
## Summary

Adds the foundational SEO + LLM-discoverability layer the site was missing.

- **`app/sitemap.ts`** — Next.js 16 sitemap convention; home + section anchors with priorities/changefreq.
- **`app/robots.ts`** — allow all, disallow `/api/`, point at sitemap, set host.
- **`app/opengraph-image.tsx`** — dynamic 1200×630 OG image via `next/og`, on-brand (terminal palette, mono).
- **`public/llms.txt`** — LLM-friendly summary: positioning, contact, stack, projects with status, engagement model.
- **`app/layout.tsx`** — expanded metadata (title template, twitter card, robots directives, keywords, canonical, authors/creator/publisher) plus JSON-LD `Person` + `WebSite` + `ProfessionalService` injected via `<script type="application/ld+json">`.

Reviewer flagged the GitHub handle for verification — it matches the existing source of truth in `components/ContactObject.tsx:14`. `dangerouslySetInnerHTML` usage was reviewed and confirmed safe (static object, no user input).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean; `/sitemap.xml`, `/robots.txt`, `/opengraph-image` all prerendered as static
- [ ] After merge: validate live `/sitemap.xml` and `/robots.txt` resolve on iwrightcode.com
- [ ] After merge: validate JSON-LD with Google Rich Results Test
- [ ] After merge: re-share a link on LinkedIn/X to confirm OG card renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)