### PR TITLE
fix(seo): use www host as canonical site URL

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ const inter = Inter({
   weight: ["400", "500"],
 });
 
-const SITE_URL = "https://iwrightcode.com";
+const SITE_URL = "https://www.iwrightcode.com";
 const SITE_NAME = "iwrightcode_";
 const TITLE = "iwrightcode_ — Isaac Wright, full-stack developer";
 const DESCRIPTION =

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const BASE_URL = "https://iwrightcode.com";
+const BASE_URL = "https://www.iwrightcode.com";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const BASE_URL = "https://iwrightcode.com";
+const BASE_URL = "https://www.iwrightcode.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ Available for contract work and fractional technical leadership. Remote, US East
 - Email: iwrightcode@gmail.com
 - GitHub: https://github.com/IsaacWrong
 - LinkedIn: https://www.linkedin.com/company/iwrightcode
-- Site: https://iwrightcode.com
+- Site: https://www.iwrightcode.com
 
 ## Stack
 
@@ -38,5 +38,5 @@ Available for contract work and fractional technical leadership. Remote, US East
 
 ## Reference
 
-- Sitemap: https://iwrightcode.com/sitemap.xml
-- Robots: https://iwrightcode.com/robots.txt
+- Sitemap: https://www.iwrightcode.com/sitemap.xml
+- Robots: https://www.iwrightcode.com/robots.txt


### PR DESCRIPTION
## Summary

Apex `iwrightcode.com` 307-redirects to `www.iwrightcode.com` at the Vercel edge. All metadata URLs (`og:url`, sitemap entries, `robots` host, JSON-LD `url`, llms.txt links) previously pointed at the apex, forcing crawlers and AI agents to follow a redirect to reach canonical content.

Switches `SITE_URL` / `BASE_URL` constants in:
- `app/layout.tsx` (drives `metadataBase`, `og:url`, JSON-LD `url`/`image`/`sameAs` base, alt names)
- `app/sitemap.ts`
- `app/robots.ts`
- `public/llms.txt`

OG image display text (`iwrightcode.com · open to work`) is left as-is — it's branding, not a crawlable URL.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` — sitemap/robots/og-image all still prerendered
- [ ] After merge: re-curl `/sitemap.xml` and `/robots.txt` to confirm `loc` and `Sitemap:` headers use the www host

🤖 Generated with [Claude Code](https://claude.com/claude-code)