### PR TITLE
release: v1.1.1

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ const inter = Inter({
   weight: ["400", "500"],
 });
 
-const SITE_URL = "https://iwrightcode.com";
+const SITE_URL = "https://www.iwrightcode.com";
 const SITE_NAME = "iwrightcode_";
 const TITLE = "iwrightcode_ — Isaac Wright, full-stack developer";
 const DESCRIPTION =

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const BASE_URL = "https://iwrightcode.com";
+const BASE_URL = "https://www.iwrightcode.com";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const BASE_URL = "https://iwrightcode.com";
+const BASE_URL = "https://www.iwrightcode.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iwrightcode",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iwrightcode",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iwrightcode",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ Available for contract work and fractional technical leadership. Remote, US East
 - Email: iwrightcode@gmail.com
 - GitHub: https://github.com/IsaacWrong
 - LinkedIn: https://www.linkedin.com/company/iwrightcode
-- Site: https://iwrightcode.com
+- Site: https://www.iwrightcode.com
 
 ## Stack
 
@@ -38,5 +38,5 @@ Available for contract work and fractional technical leadership. Remote, US East
 
 ## Reference
 
-- Sitemap: https://iwrightcode.com/sitemap.xml
-- Robots: https://iwrightcode.com/robots.txt
+- Sitemap: https://www.iwrightcode.com/sitemap.xml
+- Robots: https://www.iwrightcode.com/robots.txt


### PR DESCRIPTION
## Release v1.1.1

### What's shipping

**Fixes**
- `fix(seo)`: use www host as canonical site URL (#44) — apex was 307-redirecting to www; metadata, sitemap, robots, JSON-LD, and llms.txt now point directly at `https://www.iwrightcode.com` so crawlers don't follow a redirect to reach canonical content.

**Other**
- `chore(release)`: bump version to v1.1.1

### Pre-flight
- [x] Lint clean
- [x] Build clean
- [x] Vercel preview green on #44

### Post-merge validation
- [ ] `/sitemap.xml` `<loc>` entries use `www.iwrightcode.com`
- [ ] `/robots.txt` `Sitemap:` and `Host:` use `www.iwrightcode.com`
- [ ] Homepage `og:url` uses `www.iwrightcode.com`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)