### PR TITLE
fix(activity): resilient github fetches + live commit counts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,10 +9,12 @@ import Footer from "@/components/Footer";
 import { fetchActivity, fetchContributions } from "@/lib/github";
 
 export default async function Home() {
-  const [activity, contributions] = await Promise.all([
+  const [activityRaw, contributions] = await Promise.all([
     fetchActivity(8),
     fetchContributions(),
   ]);
+  const activity = activityRaw ?? [];
+  const activityFailed = activityRaw === null;
   const now = new Date();
 
   return (
@@ -21,7 +23,12 @@ export default async function Home() {
       <main className="flex-1">
         <Hero activity={activity} now={now} />
         <Work />
-        <Activity items={activity} now={now} contributions={contributions} />
+        <Activity
+          items={activity}
+          now={now}
+          contributions={contributions}
+          failed={activityFailed}
+        />
         <section
           id="timeline"
           className="pt-0 pb-24 px-6 md:px-10 lg:px-16"

--- a/components/Activity.tsx
+++ b/components/Activity.tsx
@@ -25,10 +25,12 @@ export default function Activity({
   items,
   now,
   contributions,
+  failed = false,
 }: {
   items: ActivityItem[];
   now: Date;
   contributions: Contributions | null;
+  failed?: boolean;
 }) {
   return (
     <section id="activity" className="py-24 px-6 md:px-10 lg:px-16">
@@ -56,10 +58,17 @@ export default function Activity({
             </>
           ) : null}
           {items.length === 0 ? (
-            <div className="text-muted">
-              <span className="text-[#FF7B72] mr-2">!</span>
-              github api unavailable — try again later.
-            </div>
+            failed ? (
+              <div className="text-muted">
+                <span className="text-[#FF7B72] mr-2">!</span>
+                github api unavailable — try again later.
+              </div>
+            ) : (
+              <div className="text-muted">
+                <span className="opacity-60 mr-2">{"//"}</span>
+                no recent public activity — most work happens in private repos.
+              </div>
+            )
           ) : (
             <ul className="space-y-1.5">
               {items.map((it) => (

--- a/components/GitGraph.tsx
+++ b/components/GitGraph.tsx
@@ -1,3 +1,5 @@
+import { fetchRepoCommitCount } from "@/lib/github";
+
 type Entry = {
   hash: string;
   ref?: string;
@@ -5,6 +7,7 @@ type Entry = {
   date: string;
   meta?: string;
   repo?: string;
+  liveCount?: boolean;
 };
 
 const log: Entry[] = [
@@ -22,6 +25,7 @@ const log: Entry[] = [
     date: "2026-04-22",
     meta: "65 commits",
     repo: "IsaacWrong/bluegrass-home-services",
+    liveCount: true,
   },
   {
     hash: "bc51582",
@@ -29,6 +33,7 @@ const log: Entry[] = [
     date: "2026-04-14",
     meta: "18 commits",
     repo: "IsaacWrong/autoform",
+    liveCount: true,
   },
   {
     hash: "7e0d8b7",
@@ -36,6 +41,7 @@ const log: Entry[] = [
     date: "2026-04-11",
     meta: "87 commits",
     repo: "IsaacWrong/exit-edge-ai",
+    liveCount: true,
   },
   {
     hash: "85ba6dd",
@@ -43,6 +49,7 @@ const log: Entry[] = [
     date: "2026-04-09",
     meta: "27 commits",
     repo: "IsaacWrong/rectorfolio",
+    liveCount: true,
   },
   {
     hash: "6050663",
@@ -50,6 +57,7 @@ const log: Entry[] = [
     date: "2026-03-17",
     meta: "156 commits",
     repo: "IsaacWrong/bookcheckr",
+    liveCount: true,
   },
   {
     hash: "2bc65ea",
@@ -57,6 +65,7 @@ const log: Entry[] = [
     date: "2025-08-19",
     meta: "748 commits",
     repo: "IsaacWrong/palm-commissions",
+    liveCount: true,
   },
   {
     hash: "0000000",
@@ -67,7 +76,29 @@ const log: Entry[] = [
   },
 ];
 
-export default function GitGraph() {
+export default async function GitGraph() {
+  const liveTargets = log
+    .map((e, i) => ({ entry: e, index: i }))
+    .filter((x) => x.entry.liveCount && x.entry.repo);
+
+  const counts = await Promise.all(
+    liveTargets.map(async (t) => {
+      const parts = (t.entry.repo as string).split("/");
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        return { index: t.index, count: null };
+      }
+      const n = await fetchRepoCommitCount(parts[0], parts[1]);
+      return { index: t.index, count: n };
+    })
+  );
+
+  const metaByIndex = new Map<number, string>();
+  for (const c of counts) {
+    if (c.count !== null) {
+      metaByIndex.set(c.index, `${c.count.toLocaleString()} commits`);
+    }
+  }
+
   return (
     <div
       className="font-mono text-[12px] overflow-x-auto"
@@ -81,8 +112,8 @@ export default function GitGraph() {
       }}
     >
       <ul className="space-y-1.5">
-        {log.map((e) => {
-          const meta = e.meta;
+        {log.map((e, i) => {
+          const meta = metaByIndex.get(i) ?? e.meta;
           return (
             <li key={e.hash} className="flex items-baseline gap-2 flex-wrap">
               <span className="text-[#FEBC2E] select-none">*</span>

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -21,7 +21,9 @@ function token(): string | undefined {
   return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 }
 
-const FETCH_TIMEOUT_MS = 5000;
+const FETCH_TIMEOUT_MS = 10000;
+const ACTIVITY_REVALIDATE_S = 600;
+const COMMIT_COUNT_REVALIDATE_S = 86400;
 
 async function ghFetch(
   url: string,
@@ -41,7 +43,7 @@ async function ghFetch(
   }
 }
 
-export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
+function ghHeaders(): Record<string, string> {
   const t = token();
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
@@ -49,14 +51,22 @@ export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
     "User-Agent": "iwrightcode-portfolio",
   };
   if (t) headers.Authorization = `Bearer ${t}`;
+  return headers;
+}
 
+export async function fetchActivity(
+  limit = 8
+): Promise<ActivityItem[] | null> {
   const url = `https://api.github.com/users/${GH_USER}/events/public?per_page=30`;
-  const res = await ghFetch(url, { headers, next: { revalidate: 3600 } });
-  if (!res) return [];
+  const res = await ghFetch(url, {
+    headers: ghHeaders(),
+    next: { revalidate: ACTIVITY_REVALIDATE_S },
+  });
+  if (!res) return null;
 
   if (!res.ok) {
     console.warn(`[github] fetchActivity status ${res.status}`);
-    return [];
+    return null;
   }
 
   let raw: unknown;
@@ -64,11 +74,11 @@ export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
     raw = await res.json();
   } catch (err) {
     console.warn("[github] fetchActivity JSON parse failed", err);
-    return [];
+    return null;
   }
   if (!Array.isArray(raw)) {
     console.warn("[github] fetchActivity unexpected shape (not array)", raw);
-    return [];
+    return null;
   }
 
   const items: ActivityItem[] = [];
@@ -78,6 +88,38 @@ export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
     if (items.length >= limit) break;
   }
   return items;
+}
+
+export async function fetchRepoCommitCount(
+  owner: string,
+  repo: string
+): Promise<number | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/commits?per_page=1`;
+  const res = await ghFetch(url, {
+    headers: ghHeaders(),
+    next: { revalidate: COMMIT_COUNT_REVALIDATE_S },
+  });
+  if (!res) return null;
+
+  if (!res.ok) {
+    console.warn(`[github] fetchRepoCommitCount ${owner}/${repo} status ${res.status}`);
+    return null;
+  }
+
+  const link = res.headers.get("Link") ?? "";
+  const lastMatch = link.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  if (lastMatch) {
+    const n = Number.parseInt(lastMatch[1], 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+
+  try {
+    const body = await res.json();
+    return Array.isArray(body) ? body.length : 0;
+  } catch (err) {
+    console.warn(`[github] fetchRepoCommitCount ${owner}/${repo} JSON parse failed`, err);
+    return null;
+  }
 }
 
 function formatEvent(ev: RawEvent): ActivityItem | null {
@@ -313,7 +355,7 @@ export async function fetchContributions(): Promise<Contributions | null> {
       query,
       variables: { user: GH_USER },
     }),
-    next: { revalidate: 3600 },
+    next: { revalidate: ACTIVITY_REVALIDATE_S },
   });
   if (!res) return null;
 


### PR DESCRIPTION
## Summary

Closes #46. Makes the activity feed survive transient GitHub API blips and surfaces real commit counts in the timeline section.

### Activity feed resilience
- Fetch timeout **5s → 10s** — the `/events/public` endpoint routinely takes 5–8s on cache miss; the old timeout was aborting valid requests
- ISR revalidate **1h → 10min** — a transient failure now blanks the section for at most 10 min, not 60
- `fetchActivity` returns `ActivityItem[] | null` instead of swallowing failures into `[]` — the UI can now tell "API failed" from "no recent public activity"
- `Activity` component shows the red `! github api unavailable` warning **only** when `failed=true`; legitimate empty (which is normal — most work happens in private repos) shows a calmer `// no recent public activity` message

### Live commit counts in timeline
- New `fetchRepoCommitCount(owner, repo)` derives total commit count from the `Link: …rel="last"` header on a `?per_page=1` request
- 24h revalidate (commit counts grow slowly)
- Defensive: handles missing Link header (single-page case), malformed `repo` strings, and any fetch failure by returning `null`
- `GitGraph` is now an async server component; fetches counts in parallel via `Promise.all`; falls back to the existing hardcoded meta strings on any per-repo failure

### Reviewer notes addressed inline
- Link header regex anchored inside `<…>` brackets to prevent path-segment false positives
- `repo.split("/")` validates exactly 2 non-empty parts before issuing the API call

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean — sitemap/robots/og-image still prerendered, route revalidate now 10m
- [ ] After merge: confirm `// activity` section repopulates within 10 min
- [ ] After merge: confirm `// timeline` shows live commit counts (or graceful fallback) for all 6 projects with `liveCount: true`
- [ ] After merge: simulate API failure (e.g., revoke token temporarily) — should show "github api unavailable" not silently empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)