### PR TITLE
release: v1.1.2

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,10 +9,12 @@ import Footer from "@/components/Footer";
 import { fetchActivity, fetchContributions } from "@/lib/github";
 
 export default async function Home() {
-  const [activity, contributions] = await Promise.all([
+  const [activityRaw, contributions] = await Promise.all([
     fetchActivity(8),
     fetchContributions(),
   ]);
+  const activity = activityRaw ?? [];
+  const activityFailed = activityRaw === null;
   const now = new Date();
 
   return (
@@ -21,7 +23,12 @@ export default async function Home() {
       <main className="flex-1">
         <Hero activity={activity} now={now} />
         <Work />
-        <Activity items={activity} now={now} contributions={contributions} />
+        <Activity
+          items={activity}
+          now={now}
+          contributions={contributions}
+          failed={activityFailed}
+        />
         <section
           id="timeline"
           className="pt-0 pb-24 px-6 md:px-10 lg:px-16"

--- a/components/Activity.tsx
+++ b/components/Activity.tsx
@@ -25,10 +25,12 @@ export default function Activity({
   items,
   now,
   contributions,
+  failed = false,
 }: {
   items: ActivityItem[];
   now: Date;
   contributions: Contributions | null;
+  failed?: boolean;
 }) {
   return (
     <section id="activity" className="py-24 px-6 md:px-10 lg:px-16">
@@ -56,10 +58,17 @@ export default function Activity({
             </>
           ) : null}
           {items.length === 0 ? (
-            <div className="text-muted">
-              <span className="text-[#FF7B72] mr-2">!</span>
-              github api unavailable — try again later.
-            </div>
+            failed ? (
+              <div className="text-muted">
+                <span className="text-[#FF7B72] mr-2">!</span>
+                github api unavailable — try again later.
+              </div>
+            ) : (
+              <div className="text-muted">
+                <span className="opacity-60 mr-2">{"//"}</span>
+                no recent public activity — most work happens in private repos.
+              </div>
+            )
           ) : (
             <ul className="space-y-1.5">
               {items.map((it) => (

--- a/components/GitGraph.tsx
+++ b/components/GitGraph.tsx
@@ -1,3 +1,5 @@
+import { fetchRepoCommitCount } from "@/lib/github";
+
 type Entry = {
   hash: string;
   ref?: string;
@@ -5,6 +7,7 @@ type Entry = {
   date: string;
   meta?: string;
   repo?: string;
+  liveCount?: boolean;
 };
 
 const log: Entry[] = [
@@ -22,6 +25,7 @@ const log: Entry[] = [
     date: "2026-04-22",
     meta: "65 commits",
     repo: "IsaacWrong/bluegrass-home-services",
+    liveCount: true,
   },
   {
     hash: "bc51582",
@@ -29,6 +33,7 @@ const log: Entry[] = [
     date: "2026-04-14",
     meta: "18 commits",
     repo: "IsaacWrong/autoform",
+    liveCount: true,
   },
   {
     hash: "7e0d8b7",
@@ -36,6 +41,7 @@ const log: Entry[] = [
     date: "2026-04-11",
     meta: "87 commits",
     repo: "IsaacWrong/exit-edge-ai",
+    liveCount: true,
   },
   {
     hash: "85ba6dd",
@@ -43,6 +49,7 @@ const log: Entry[] = [
     date: "2026-04-09",
     meta: "27 commits",
     repo: "IsaacWrong/rectorfolio",
+    liveCount: true,
   },
   {
     hash: "6050663",
@@ -50,6 +57,7 @@ const log: Entry[] = [
     date: "2026-03-17",
     meta: "156 commits",
     repo: "IsaacWrong/bookcheckr",
+    liveCount: true,
   },
   {
     hash: "2bc65ea",
@@ -57,6 +65,7 @@ const log: Entry[] = [
     date: "2025-08-19",
     meta: "748 commits",
     repo: "IsaacWrong/palm-commissions",
+    liveCount: true,
   },
   {
     hash: "0000000",
@@ -67,7 +76,29 @@ const log: Entry[] = [
   },
 ];
 
-export default function GitGraph() {
+export default async function GitGraph() {
+  const liveTargets = log
+    .map((e, i) => ({ entry: e, index: i }))
+    .filter((x) => x.entry.liveCount && x.entry.repo);
+
+  const counts = await Promise.all(
+    liveTargets.map(async (t) => {
+      const parts = (t.entry.repo as string).split("/");
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        return { index: t.index, count: null };
+      }
+      const n = await fetchRepoCommitCount(parts[0], parts[1]);
+      return { index: t.index, count: n };
+    })
+  );
+
+  const metaByIndex = new Map<number, string>();
+  for (const c of counts) {
+    if (c.count !== null) {
+      metaByIndex.set(c.index, `${c.count.toLocaleString()} commits`);
+    }
+  }
+
   return (
     <div
       className="font-mono text-[12px] overflow-x-auto"
@@ -81,8 +112,8 @@ export default function GitGraph() {
       }}
     >
       <ul className="space-y-1.5">
-        {log.map((e) => {
-          const meta = e.meta;
+        {log.map((e, i) => {
+          const meta = metaByIndex.get(i) ?? e.meta;
           return (
             <li key={e.hash} className="flex items-baseline gap-2 flex-wrap">
               <span className="text-[#FEBC2E] select-none">*</span>

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -21,7 +21,9 @@ function token(): string | undefined {
   return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 }
 
-const FETCH_TIMEOUT_MS = 5000;
+const FETCH_TIMEOUT_MS = 10000;
+const ACTIVITY_REVALIDATE_S = 600;
+const COMMIT_COUNT_REVALIDATE_S = 86400;
 
 async function ghFetch(
   url: string,
@@ -41,7 +43,7 @@ async function ghFetch(
   }
 }
 
-export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
+function ghHeaders(): Record<string, string> {
   const t = token();
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
@@ -49,14 +51,22 @@ export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
     "User-Agent": "iwrightcode-portfolio",
   };
   if (t) headers.Authorization = `Bearer ${t}`;
+  return headers;
+}
 
+export async function fetchActivity(
+  limit = 8
+): Promise<ActivityItem[] | null> {
   const url = `https://api.github.com/users/${GH_USER}/events/public?per_page=30`;
-  const res = await ghFetch(url, { headers, next: { revalidate: 3600 } });
-  if (!res) return [];
+  const res = await ghFetch(url, {
+    headers: ghHeaders(),
+    next: { revalidate: ACTIVITY_REVALIDATE_S },
+  });
+  if (!res) return null;
 
   if (!res.ok) {
     console.warn(`[github] fetchActivity status ${res.status}`);
-    return [];
+    return null;
   }
 
   let raw: unknown;
@@ -64,11 +74,11 @@ export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
     raw = await res.json();
   } catch (err) {
     console.warn("[github] fetchActivity JSON parse failed", err);
-    return [];
+    return null;
   }
   if (!Array.isArray(raw)) {
     console.warn("[github] fetchActivity unexpected shape (not array)", raw);
-    return [];
+    return null;
   }
 
   const items: ActivityItem[] = [];
@@ -78,6 +88,38 @@ export async function fetchActivity(limit = 8): Promise<ActivityItem[]> {
     if (items.length >= limit) break;
   }
   return items;
+}
+
+export async function fetchRepoCommitCount(
+  owner: string,
+  repo: string
+): Promise<number | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/commits?per_page=1`;
+  const res = await ghFetch(url, {
+    headers: ghHeaders(),
+    next: { revalidate: COMMIT_COUNT_REVALIDATE_S },
+  });
+  if (!res) return null;
+
+  if (!res.ok) {
+    console.warn(`[github] fetchRepoCommitCount ${owner}/${repo} status ${res.status}`);
+    return null;
+  }
+
+  const link = res.headers.get("Link") ?? "";
+  const lastMatch = link.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  if (lastMatch) {
+    const n = Number.parseInt(lastMatch[1], 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+
+  try {
+    const body = await res.json();
+    return Array.isArray(body) ? body.length : 0;
+  } catch (err) {
+    console.warn(`[github] fetchRepoCommitCount ${owner}/${repo} JSON parse failed`, err);
+    return null;
+  }
 }
 
 function formatEvent(ev: RawEvent): ActivityItem | null {
@@ -313,7 +355,7 @@ export async function fetchContributions(): Promise<Contributions | null> {
       query,
       variables: { user: GH_USER },
     }),
-    next: { revalidate: 3600 },
+    next: { revalidate: ACTIVITY_REVALIDATE_S },
   });
   if (!res) return null;
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -22,17 +22,19 @@ function token(): string | undefined {
 }
 
 const FETCH_TIMEOUT_MS = 10000;
+const COMMIT_COUNT_TIMEOUT_MS = 3000;
 const ACTIVITY_REVALIDATE_S = 600;
 const COMMIT_COUNT_REVALIDATE_S = 86400;
 
 async function ghFetch(
   url: string,
-  init: RequestInit & { next?: { revalidate?: number } } = {}
+  init: RequestInit & { next?: { revalidate?: number }; timeoutMs?: number } = {}
 ): Promise<Response | null> {
+  const { timeoutMs = FETCH_TIMEOUT_MS, ...rest } = init;
   const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    return await fetch(url, { ...init, signal: ctrl.signal });
+    return await fetch(url, { ...rest, signal: ctrl.signal });
   } catch (err) {
     const reason =
       err instanceof Error && err.name === "AbortError" ? "timeout" : "network";
@@ -98,6 +100,7 @@ export async function fetchRepoCommitCount(
   const res = await ghFetch(url, {
     headers: ghHeaders(),
     next: { revalidate: COMMIT_COUNT_REVALIDATE_S },
+    timeoutMs: COMMIT_COUNT_TIMEOUT_MS,
   });
   if (!res) return null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iwrightcode",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iwrightcode",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iwrightcode",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.1.2

### What's shipping

**Fixes**
- `fix(activity)`: make github fetches resilient and surface live commit counts (#49) — 10s timeout, 10min revalidate, distinguish `null` (failed) from `[]` (normal empty), live commit counts in timeline section via `Link: rel="last"` parsing
- `fix(github)`: cap commit-count fetch at 3s to bound cold-render latency (#50) — per-call `timeoutMs` on `ghFetch`; activity keeps 10s, commit-count drops to 3s

**Other**
- `chore(release)`: bump version to v1.1.2

### Pre-flight
- [x] Lint clean
- [x] Build clean
- [x] Vercel preview green on #49 and #50
- [x] No open critical/high blockers (#47 closed, #48 fixed in #50)

### Post-merge validation
- [ ] `// activity` section shows recent activity or calmer "no recent public activity" message (not red warning) on healthy API
- [ ] `// timeline` section shows live commit counts for all 6 `liveCount: true` projects

🤖 Generated with [Claude Code](https://claude.ai/claude-code)