### PR TITLE
feat(activity): include private events as redacted entries

### DIFF
--- a/components/Activity.tsx
+++ b/components/Activity.tsx
@@ -66,7 +66,7 @@ export default function Activity({
             ) : (
               <div className="text-muted">
                 <span className="opacity-60 mr-2">{"//"}</span>
-                no recent public activity — most work happens in private repos.
+                no recent activity — try again later.
               </div>
             )
           ) : (
@@ -100,7 +100,7 @@ export default function Activity({
           )}
           <p className="text-muted mt-4 text-[11px] select-none">
             <span className="opacity-60">{"// "}</span>
-            cached for 1h · public events only
+            cached for 10m · private events redacted
           </p>
         </div>
       </div>

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -5,6 +5,7 @@ export type ActivityItem = {
   tone: "push" | "merge" | "create" | "star" | "release" | "issue" | "delete" | "other";
   text: string;
   href?: string;
+  isPrivate?: boolean;
 };
 
 const GH_USER = "IsaacWrong";
@@ -13,6 +14,7 @@ type RawEvent = {
   id: string;
   type: string;
   created_at: string;
+  public?: boolean;
   repo: { name: string; url: string };
   payload: Record<string, unknown>;
 };
@@ -59,7 +61,7 @@ function ghHeaders(): Record<string, string> {
 export async function fetchActivity(
   limit = 8
 ): Promise<ActivityItem[] | null> {
-  const url = `https://api.github.com/users/${GH_USER}/events/public?per_page=30`;
+  const url = `https://api.github.com/users/${GH_USER}/events?per_page=30`;
   const res = await ghFetch(url, {
     headers: ghHeaders(),
     next: { revalidate: ACTIVITY_REVALIDATE_S },
@@ -85,11 +87,51 @@ export async function fetchActivity(
 
   const items: ActivityItem[] = [];
   for (const ev of raw as RawEvent[]) {
-    const formatted = formatEvent(ev);
-    if (formatted) items.push(formatted);
+    if (ev.public === false) {
+      const redacted = redactPrivateEvent(ev);
+      if (redacted) items.push(redacted);
+    } else {
+      const formatted = formatEvent(ev);
+      if (formatted) items.push(formatted);
+    }
     if (items.length >= limit) break;
   }
   return items;
+}
+
+function redactPrivateEvent(ev: RawEvent): ActivityItem | null {
+  const when = new Date(ev.created_at);
+  if (Number.isNaN(when.getTime())) return null;
+  const verb = privateVerbForType(ev.type);
+  return {
+    id: ev.id,
+    when,
+    prefix: "·",
+    tone: "other",
+    text: `${verb} in private repo`,
+    isPrivate: true,
+  };
+}
+
+function privateVerbForType(type: string): string {
+  switch (type) {
+    case "PushEvent":
+      return "pushed commits";
+    case "PullRequestEvent":
+      return "worked on a PR";
+    case "PullRequestReviewEvent":
+      return "reviewed a PR";
+    case "IssuesEvent":
+      return "worked on an issue";
+    case "ReleaseEvent":
+      return "shipped a release";
+    case "CreateEvent":
+      return "created branch/tag";
+    case "DeleteEvent":
+      return "deleted branch/tag";
+    default:
+      return "committed";
+  }
 }
 
 export async function fetchRepoCommitCount(


### PR DESCRIPTION
## Summary

Hero `// last update:` line and `// activity` section now reflect work in private repos too — redacted to a generic verb + "in private repo" with no repo name and no href. Solves the case where Hero went stale whenever recent activity lived in private repos.

### Changes
- `lib/github.ts`:
  - `ActivityItem.isPrivate?: boolean` added
  - `RawEvent.public?: boolean` typed
  - `fetchActivity` URL: `/users/${user}/events/public` → `/users/${user}/events` (auth token now sees private events too)
  - New `redactPrivateEvent` + `privateVerbForType` produce neutral text per event type
- `components/Activity.tsx`:
  - Empty-state copy: "no recent public activity" → "no recent activity"
  - Footer caption: "cached for 1h · public events only" → "cached for 10m · private events redacted"

### Verification
Probed `/users/IsaacWrong/events?per_page=100` with the new token: 48 private events from `Palm-Commissions` and 52 public from `iwrightcode` visible — code will redact the former to `… in private repo`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] After merge: Hero `// last update:` reflects most recent activity (public or private)
- [ ] After merge: `// activity` section shows mixed feed; private entries say "X in private repo" with no link

🤖 Generated with [Claude Code](https://claude.com/claude-code)