### PR TITLE
release: v1.2.0

### DIFF
--- a/components/Activity.tsx
+++ b/components/Activity.tsx
@@ -66,7 +66,7 @@ export default function Activity({
             ) : (
               <div className="text-muted">
                 <span className="opacity-60 mr-2">{"//"}</span>
-                no recent public activity — most work happens in private repos.
+                no recent activity — try again later.
               </div>
             )
           ) : (
@@ -100,7 +100,7 @@ export default function Activity({
           )}
           <p className="text-muted mt-4 text-[11px] select-none">
             <span className="opacity-60">{"// "}</span>
-            cached for 1h · public events only
+            cached for 10m · private events redacted
           </p>
         </div>
       </div>

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -5,6 +5,7 @@ export type ActivityItem = {
   tone: "push" | "merge" | "create" | "star" | "release" | "issue" | "delete" | "other";
   text: string;
   href?: string;
+  isPrivate?: boolean;
 };
 
 const GH_USER = "IsaacWrong";
@@ -13,6 +14,7 @@ type RawEvent = {
   id: string;
   type: string;
   created_at: string;
+  public?: boolean;
   repo: { name: string; url: string };
   payload: Record<string, unknown>;
 };
@@ -59,7 +61,7 @@ function ghHeaders(): Record<string, string> {
 export async function fetchActivity(
   limit = 8
 ): Promise<ActivityItem[] | null> {
-  const url = `https://api.github.com/users/${GH_USER}/events/public?per_page=30`;
+  const url = `https://api.github.com/users/${GH_USER}/events?per_page=30`;
   const res = await ghFetch(url, {
     headers: ghHeaders(),
     next: { revalidate: ACTIVITY_REVALIDATE_S },
@@ -85,11 +87,51 @@ export async function fetchActivity(
 
   const items: ActivityItem[] = [];
   for (const ev of raw as RawEvent[]) {
-    const formatted = formatEvent(ev);
-    if (formatted) items.push(formatted);
+    if (ev.public === false) {
+      const redacted = redactPrivateEvent(ev);
+      if (redacted) items.push(redacted);
+    } else {
+      const formatted = formatEvent(ev);
+      if (formatted) items.push(formatted);
+    }
     if (items.length >= limit) break;
   }
   return items;
+}
+
+function redactPrivateEvent(ev: RawEvent): ActivityItem | null {
+  const when = new Date(ev.created_at);
+  if (Number.isNaN(when.getTime())) return null;
+  const verb = privateVerbForType(ev.type);
+  return {
+    id: ev.id,
+    when,
+    prefix: "·",
+    tone: "other",
+    text: `${verb} in private repo`,
+    isPrivate: true,
+  };
+}
+
+function privateVerbForType(type: string): string {
+  switch (type) {
+    case "PushEvent":
+      return "pushed commits";
+    case "PullRequestEvent":
+      return "worked on a PR";
+    case "PullRequestReviewEvent":
+      return "reviewed a PR";
+    case "IssuesEvent":
+      return "worked on an issue";
+    case "ReleaseEvent":
+      return "shipped a release";
+    case "CreateEvent":
+      return "created branch/tag";
+    case "DeleteEvent":
+      return "deleted branch/tag";
+    default:
+      return "committed";
+  }
 }
 
 export async function fetchRepoCommitCount(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iwrightcode",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iwrightcode",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iwrightcode",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.2.0

### What's shipping

**Features**
- `feat(activity)`: include private events as redacted entries (#52) — Hero `// last update:` and `// activity` section now reflect work in private repos. Private events render as generic redacted strings ("pushed commits in private repo", "worked on a PR in private repo", etc.) with no href and no repo name. Switched `/events/public` → `/events` so the authenticated `GITHUB_TOKEN` returns both visibility tiers.

**Other**
- `chore(release)`: bump version to v1.2.0

### Pre-flight
- [x] Lint clean
- [x] Build clean
- [x] Vercel preview green on #52
- [x] No open critical/high blockers

### Post-merge validation
- [ ] Hero `// last update:` line reflects most recent action regardless of repo visibility
- [ ] `// activity` section shows mixed feed; private entries say "X in private repo" with no link
- [ ] `// timeline` commit counts continue to render (regression check after token scope change last release)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)