### PR TITLE
fix(activity): fail-closed redaction gate + round private timestamps

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -87,7 +87,7 @@ export async function fetchActivity(
 
   const items: ActivityItem[] = [];
   for (const ev of raw as RawEvent[]) {
-    if (ev.public === false) {
+    if (ev.public !== true) {
       const redacted = redactPrivateEvent(ev);
       if (redacted) items.push(redacted);
     } else {
@@ -99,9 +99,12 @@ export async function fetchActivity(
   return items;
 }
 
+const PRIVATE_TIMESTAMP_ROUND_MS = 60 * 60 * 1000;
+
 function redactPrivateEvent(ev: RawEvent): ActivityItem | null {
-  const when = new Date(ev.created_at);
-  if (Number.isNaN(when.getTime())) return null;
+  const raw = new Date(ev.created_at).getTime();
+  if (Number.isNaN(raw)) return null;
+  const when = new Date(Math.floor(raw / PRIVATE_TIMESTAMP_ROUND_MS) * PRIVATE_TIMESTAMP_ROUND_MS);
   const verb = privateVerbForType(ev.type);
   return {
     id: ev.id,


### PR DESCRIPTION
## Summary

Hardens the private-event redaction added in #52.

### Fail-closed gate
- Was: `if (ev.public === false)` → redact, `else` → formatEvent
- Now: `if (ev.public !== true)` → redact, `else` → formatEvent

If GitHub's response ever omits the `public` field on a private event (API change, partial shape, unexpected payload), the event now routes through redaction instead of `formatEvent`, which reads `ev.repo.name` and `ev.payload` and would leak both.

### Timestamp rounding
Private event timestamps round down to the hour before serialization. Relative-time UI (`Xh ago`) is visually identical. Removes minute/second precision that pattern observers could use to correlate exact push cadence.

Public events keep full precision.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] After merge: any private events in feed render with hour-aligned `when` timestamps in serialized props

🤖 Generated with [Claude Code](https://claude.com/claude-code)