### PR TITLE
release: v1.2.1

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -87,7 +87,7 @@ export async function fetchActivity(
 
   const items: ActivityItem[] = [];
   for (const ev of raw as RawEvent[]) {
-    if (ev.public === false) {
+    if (ev.public !== true) {
       const redacted = redactPrivateEvent(ev);
       if (redacted) items.push(redacted);
     } else {
@@ -99,9 +99,12 @@ export async function fetchActivity(
   return items;
 }
 
+const PRIVATE_TIMESTAMP_ROUND_MS = 60 * 60 * 1000;
+
 function redactPrivateEvent(ev: RawEvent): ActivityItem | null {
-  const when = new Date(ev.created_at);
-  if (Number.isNaN(when.getTime())) return null;
+  const raw = new Date(ev.created_at).getTime();
+  if (Number.isNaN(raw)) return null;
+  const when = new Date(Math.floor(raw / PRIVATE_TIMESTAMP_ROUND_MS) * PRIVATE_TIMESTAMP_ROUND_MS);
   const verb = privateVerbForType(ev.type);
   return {
     id: ev.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iwrightcode",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iwrightcode",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iwrightcode",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.2.1

### What's shipping

**Fixes**
- `fix(activity)`: fail-closed redaction gate + round private timestamps (#54) — gate flips from `ev.public === false` to `ev.public !== true` so any event missing the public field routes through redaction (was leaking repo name + payload through formatEvent if API shape changed). Private event timestamps round down to the hour to remove minute/second push-cadence precision.

**Other**
- `chore(release)`: bump version to v1.2.1

### Pre-flight
- [x] Lint clean
- [x] Build clean
- [x] Vercel preview green on #54
- [x] No open critical/high blockers

### Post-merge validation
- [ ] Live HTML contains no private repo names in activity items
- [ ] Private item timestamps in serialized props are hour-aligned

🤖 Generated with [Claude Code](https://claude.ai/claude-code)