### PR TITLE
fix: issue-bot batch — 16 issues

### DIFF
--- a/app/api/visitor/route.ts
+++ b/app/api/visitor/route.ts
@@ -169,7 +169,7 @@ export async function POST(req: Request) {
       clearTimeout(timeout);
     }
   } else {
-    console.log(`[visitor] ${email} (ip=${safeIp}) — no RESEND_API_KEY set`);
+    console.warn("[visitor] RESEND_API_KEY not set — submission accepted but not delivered");
   }
 
   return NextResponse.json({ ok: true });

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
 
-export default function GlobalError({
+export default function RouteError({
   error,
   reset,
 }: {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -5,7 +5,49 @@ export const alt =
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-export default function OpengraphImage() {
+const JETBRAINS_MONO_400 =
+  "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf";
+const JETBRAINS_MONO_500 =
+  "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-500-normal.ttf";
+
+async function loadFont(url: string): Promise<ArrayBuffer | null> {
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: 60 * 60 * 24 * 30 },
+    });
+    if (!res.ok) return null;
+    return await res.arrayBuffer();
+  } catch {
+    return null;
+  }
+}
+
+export default async function OpengraphImage() {
+  const [regular, medium] = await Promise.all([
+    loadFont(JETBRAINS_MONO_400),
+    loadFont(JETBRAINS_MONO_500),
+  ]);
+
+  const fonts =
+    regular && medium
+      ? [
+          {
+            name: "JetBrains Mono",
+            data: regular,
+            style: "normal" as const,
+            weight: 400 as const,
+          },
+          {
+            name: "JetBrains Mono",
+            data: medium,
+            style: "normal" as const,
+            weight: 500 as const,
+          },
+        ]
+      : undefined;
+
+  const fontFamily = fonts ? "JetBrains Mono" : "monospace";
+
   return new ImageResponse(
     (
       <div
@@ -18,7 +60,7 @@ export default function OpengraphImage() {
           padding: "72px 80px",
           background: "#0D1117",
           color: "#E6EDF3",
-          fontFamily: "monospace",
+          fontFamily,
         }}
       >
         <div
@@ -92,6 +134,6 @@ export default function OpengraphImage() {
         </div>
       </div>
     ),
-    { ...size }
+    { ...size, fonts }
   );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,38 +3,12 @@ import type { MetadataRoute } from "next";
 const BASE_URL = "https://www.iwrightcode.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const lastModified = new Date();
-
   return [
     {
       url: BASE_URL,
-      lastModified,
+      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
-    },
-    {
-      url: `${BASE_URL}/#work`,
-      lastModified,
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/#activity`,
-      lastModified,
-      changeFrequency: "daily",
-      priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/#about`,
-      lastModified,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/#contact`,
-      lastModified,
-      changeFrequency: "monthly",
-      priority: 0.8,
     },
   ];
 }

--- a/components/Activity.tsx
+++ b/components/Activity.tsx
@@ -60,12 +60,12 @@ export default function Activity({
           {items.length === 0 ? (
             failed ? (
               <div className="text-muted">
-                <span className="text-[#FF7B72] mr-2">!</span>
+                <span aria-hidden="true" className="text-[#FF7B72] mr-2">!</span>
                 github api unavailable — try again later.
               </div>
             ) : (
               <div className="text-muted">
-                <span className="opacity-60 mr-2">{"//"}</span>
+                <span aria-hidden="true" className="opacity-60 mr-2">{"//"}</span>
                 no recent activity — try again later.
               </div>
             )
@@ -79,7 +79,7 @@ export default function Activity({
                   <span className="text-muted tabular-nums">
                     {relativeTime(it.when, now)}
                   </span>
-                  <span className={`${toneClass(it.tone)} text-center select-none`}>
+                  <span aria-hidden="true" className={`${toneClass(it.tone)} text-center select-none`}>
                     {it.prefix}
                   </span>
                   {it.href ? (

--- a/components/CommandLayer.tsx
+++ b/components/CommandLayer.tsx
@@ -2,6 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { projects } from "@/lib/projects";
+import {
+  CONTACT_EMAIL as EMAIL,
+  GITHUB_URL as GH,
+  LINKEDIN_URL as LI,
+} from "@/lib/contact";
 
 type Action = {
   id: string;
@@ -11,10 +16,6 @@ type Action = {
   keywords?: string;
   run: () => void;
 };
-
-const EMAIL = "iwrightcode@gmail.com";
-const GH = "https://github.com/IsaacWrong";
-const LI = "https://www.linkedin.com/company/iwrightcode";
 
 function jump(hash: string) {
   if (typeof window === "undefined") return;

--- a/components/ContactObject.tsx
+++ b/components/ContactObject.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useState } from "react";
-
-const EMAIL = "iwrightcode@gmail.com";
+import {
+  CONTACT_EMAIL as EMAIL,
+  GITHUB_URL,
+  GITHUB_HANDLE,
+  LINKEDIN_URL,
+  LINKEDIN_HANDLE,
+} from "@/lib/contact";
 
 type Social = {
   label: string;
@@ -11,12 +16,8 @@ type Social = {
 };
 
 const socials: Social[] = [
-  { label: "github", handle: "IsaacWrong", href: "https://github.com/IsaacWrong" },
-  {
-    label: "linkedin",
-    handle: "iwrightcode",
-    href: "https://www.linkedin.com/company/iwrightcode",
-  },
+  { label: "github", handle: GITHUB_HANDLE, href: GITHUB_URL },
+  { label: "linkedin", handle: LINKEDIN_HANDLE, href: LINKEDIN_URL },
 ];
 
 export default function ContactObject() {

--- a/components/GitGraph.tsx
+++ b/components/GitGraph.tsx
@@ -83,7 +83,9 @@ export default async function GitGraph() {
 
   const counts = await Promise.all(
     liveTargets.map(async (t) => {
-      const parts = (t.entry.repo as string).split("/");
+      const repo = t.entry.repo;
+      if (!repo) return { index: t.index, count: null };
+      const parts = repo.split("/");
       if (parts.length !== 2 || !parts[0] || !parts[1]) {
         return { index: t.index, count: null };
       }

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import type { Project } from "@/lib/projects";
+import { isExternalHref, type Project } from "@/lib/projects";
 
 function diffLine(project: Project): { prefix: string; text: string; tone: "add" | "wip" } {
   if (project.href) {
-    const isExternal = /^https?:\/\//.test(project.href);
+    const isExternal = isExternalHref(project.href);
     if (isExternal) {
       const host = project.href.replace(/^https?:\/\//, "").replace(/\/$/, "");
       return { prefix: "+", text: `deploy → ${host}`, tone: "add" };
@@ -69,7 +69,7 @@ export default function ProjectCard({ project }: { project: Project }) {
     return <div className="group">{inner}</div>;
   }
 
-  const isExternal = /^https?:\/\//.test(project.href);
+  const isExternal = isExternalHref(project.href);
   if (isExternal) {
     return (
       <a

--- a/components/SpotlightGrid.tsx
+++ b/components/SpotlightGrid.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { useReducedMotion } from "@/lib/useReducedMotion";
 
 export default function SpotlightGrid() {
   const ref = useRef<HTMLDivElement>(null);
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     const node = ref.current;
     if (!node) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    if (reducedMotion) return;
     if (window.matchMedia("(hover: none)").matches) return;
 
     let raf = 0;
@@ -61,7 +63,7 @@ export default function SpotlightGrid() {
       detach();
       if (raf) cancelAnimationFrame(raf);
     };
-  }, []);
+  }, [reducedMotion]);
 
   return (
     <div

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -419,16 +419,19 @@ export default function Terminal({ activity = [] }: Props) {
     [activity, username]
   );
 
+  const submitShell = (value: string) => {
+    setShellInput("");
+    if (value.trim().length > 0) {
+      setHistory((h) => [...h, value]);
+    }
+    historyIdxRef.current = -1;
+    runCommand(value);
+  };
+
   const onShellKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      const value = shellInput;
-      setShellInput("");
-      if (value.trim().length > 0) {
-        setHistory((h) => [...h, value]);
-      }
-      historyIdxRef.current = -1;
-      runCommand(value);
+      submitShell(shellInput);
       return;
     }
     if (e.key === "ArrowUp") {
@@ -623,11 +626,7 @@ export default function Terminal({ activity = [] }: Props) {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
-                const value = shellInput;
-                setShellInput("");
-                if (value.trim().length > 0) setHistory((h) => [...h, value]);
-                historyIdxRef.current = -1;
-                runCommand(value);
+                submitShell(shellInput);
               }}
               className="flex items-center"
             >

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -167,15 +167,7 @@ export default function Terminal({ activity = [] }: Props) {
     return local.toLowerCase().slice(0, 16);
   }, [userEmail]);
 
-  const promptPrefix = (
-    <>
-      <span className="text-[#7ee787]">{username}</span>
-      <span className="text-muted">@iwrightcode</span>
-      <span className="text-muted">:</span>
-      <span className="text-[#79C0FF]">~</span>
-      <span className="text-muted mr-2">$</span>
-    </>
-  );
+  const promptPrefix = <TerminalPrompt user={username} />;
 
   const runCommand = useCallback(
     (raw: string) => {
@@ -649,15 +641,23 @@ export default function Terminal({ activity = [] }: Props) {
   );
 }
 
+function TerminalPrompt({ user }: { user: string }) {
+  return (
+    <>
+      <span className="text-[#7ee787]">{user}</span>
+      <span className="text-muted">@iwrightcode</span>
+      <span className="text-muted">:</span>
+      <span className="text-[#79C0FF]">~</span>
+      <span aria-hidden="true" className="text-muted mr-2">$</span>
+    </>
+  );
+}
+
 function ShellRow({ block }: { block: ShellBlock }) {
   if (block.kind === "command") {
     return (
       <div>
-        <span className="text-[#7ee787]">{block.user}</span>
-        <span className="text-muted">@iwrightcode</span>
-        <span className="text-muted">:</span>
-        <span className="text-[#79C0FF]">~</span>
-        <span className="text-muted mr-2">$</span>
+        <TerminalPrompt user={block.user} />
         <span className="text-fg">{block.text}</span>
       </div>
     );

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -11,6 +11,11 @@ import { useReducedMotion } from "@/lib/useReducedMotion";
 import { projects } from "@/lib/projects";
 import type { ActivityItem } from "@/lib/github";
 import { relativeTime } from "@/lib/github";
+import {
+  CONTACT_EMAIL,
+  GITHUB_HANDLE,
+  LINKEDIN_HANDLE,
+} from "@/lib/contact";
 
 type DemoLine = {
   prompt: boolean;
@@ -245,9 +250,9 @@ export default function Terminal({ activity = [] }: Props) {
             next.push({
               kind: "output",
               lines: [
-                "email:    iwrightcode@gmail.com",
-                "github:   IsaacWrong",
-                "linkedin: iwrightcode",
+                `email:    ${CONTACT_EMAIL}`,
+                `github:   ${GITHUB_HANDLE}`,
+                `linkedin: ${LINKEDIN_HANDLE}`,
                 "status:   open to work",
               ],
             });
@@ -272,9 +277,9 @@ export default function Terminal({ activity = [] }: Props) {
           next.push({
             kind: "output",
             lines: [
-              "email:    iwrightcode@gmail.com",
-              "github:   IsaacWrong",
-              "linkedin: iwrightcode",
+              `email:    ${CONTACT_EMAIL}`,
+              `github:   ${GITHUB_HANDLE}`,
+              `linkedin: ${LINKEDIN_HANDLE}`,
             ],
           });
           break;
@@ -349,7 +354,7 @@ export default function Terminal({ activity = [] }: Props) {
                 <span>
                   <span className="text-[#7ee787]">access granted.</span>{" "}
                   <a
-                    href="mailto:iwrightcode@gmail.com?subject=let%27s%20build%20something"
+                    href={`mailto:${CONTACT_EMAIL}?subject=let%27s%20build%20something`}
                     className="text-fg underline underline-offset-4 hover:opacity-80"
                   >
                     opening mail.app →

--- a/components/Work.tsx
+++ b/components/Work.tsx
@@ -1,4 +1,4 @@
-import { projects, type Project } from "@/lib/projects";
+import { projects, isExternalHref, type Project } from "@/lib/projects";
 import ProjectCard from "./ProjectCard";
 import SectionHeading from "./SectionHeading";
 
@@ -62,7 +62,7 @@ function BuildingRow({ project }: { project: Project }) {
   );
 
   if (project.href) {
-    const isExternal = /^https?:\/\//.test(project.href);
+    const isExternal = isExternalHref(project.href);
     return (
       <li>
         <a

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -1,0 +1,5 @@
+export const CONTACT_EMAIL = "iwrightcode@gmail.com";
+export const GITHUB_URL = "https://github.com/IsaacWrong";
+export const GITHUB_HANDLE = "IsaacWrong";
+export const LINKEDIN_URL = "https://www.linkedin.com/company/iwrightcode";
+export const LINKEDIN_HANDLE = "iwrightcode";

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -86,12 +86,17 @@ export async function fetchActivity(
   }
 
   const items: ActivityItem[] = [];
-  for (const ev of raw as RawEvent[]) {
-    if (ev.public !== true) {
-      const redacted = redactPrivateEvent(ev);
+  for (const ev of raw as unknown[]) {
+    if (typeof ev !== "object" || ev === null) {
+      console.warn("[github] fetchActivity skipping non-object element", typeof ev);
+      continue;
+    }
+    const evt = ev as RawEvent;
+    if (evt.public !== true) {
+      const redacted = redactPrivateEvent(evt);
       if (redacted) items.push(redacted);
     } else {
-      const formatted = formatEvent(ev);
+      const formatted = formatEvent(evt);
       if (formatted) items.push(formatted);
     }
     if (items.length >= limit) break;

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -367,6 +367,7 @@ type ContribGraphQLResponse = {
       };
     };
   };
+  errors?: Array<{ message?: string; type?: string }>;
 };
 
 export async function fetchContributions(): Promise<Contributions | null> {
@@ -417,6 +418,14 @@ export async function fetchContributions(): Promise<Contributions | null> {
     body = (await res.json()) as ContribGraphQLResponse;
   } catch (err) {
     console.warn("[github] fetchContributions JSON parse failed", err);
+    return null;
+  }
+
+  if (Array.isArray(body.errors) && body.errors.length > 0) {
+    console.warn(
+      "[github] fetchContributions GraphQL errors",
+      body.errors.map((e) => e.message ?? e.type ?? "unknown").slice(0, 5)
+    );
     return null;
   }
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -81,7 +81,11 @@ export async function fetchActivity(
     return null;
   }
   if (!Array.isArray(raw)) {
-    console.warn("[github] fetchActivity unexpected shape (not array)", raw);
+    const shape =
+      typeof raw === "object" && raw !== null
+        ? Object.keys(raw as Record<string, unknown>).slice(0, 5)
+        : typeof raw;
+    console.warn("[github] fetchActivity unexpected shape (not array)", shape);
     return null;
   }
 

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,3 +1,7 @@
+export function isExternalHref(href: string): boolean {
+  return /^https?:\/\//.test(href);
+}
+
 export type Project = {
   slug: string;
   name: string;

--- a/lib/useReducedMotion.ts
+++ b/lib/useReducedMotion.ts
@@ -1,19 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 const QUERY = "(prefers-reduced-motion: reduce)";
 
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", onChange);
+  return () => mql.removeEventListener("change", onChange);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
 export function useReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-
-  useEffect(() => {
-    const mql = window.matchMedia(QUERY);
-    const update = () => setReduced(mql.matches);
-    update();
-    mql.addEventListener("change", update);
-    return () => mql.removeEventListener("change", update);
-  }, []);
-
-  return reduced;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"
-  }
+  },
+  "browserslist": [
+    "chrome >= 100",
+    "firefox >= 100",
+    "safari >= 15.4",
+    "edge >= 100"
+  ]
 }


### PR DESCRIPTION
## Summary

Automated `/issue-bot` run fixing 16 issues from the open backlog (audit waves 1–3 fallout). 10 auto-fix + 6 assisted. Each fix is a separate commit — revert any individually if needed.

## Results

| # | Title | Tier | Status |
|---|---|---|---|
| #38 | a11y: prefix glyphs not hidden from AT | auto | fixed |
| #56 | GraphQL errors silently ignored in fetchContributions | auto | fixed |
| #57 | raw event array elements cast without shape guard | auto | fixed |
| #61 | fetchActivity logs unredacted body to logs | auto | fixed |
| #62 | /api/visitor logs visitor email to stdout | auto | fixed |
| #66 | SpotlightGrid bypasses useReducedMotion hook | auto | fixed |
| #68 | unnecessary `as string` cast in GitGraph | auto | fixed |
| #74 | error.tsx component named `GlobalError` | auto | fixed |
| #75 | sitemap anchor entries are invalid | auto | fixed |
| #80 | drop legacy-JS polyfills via browserslist | auto | fixed |
| #64 | Terminal duplicated submit logic | assisted | fixed |
| #65 | Terminal duplicated prompt JSX | assisted | fixed |
| #67 | Contact constants duplicated 3+ files | assisted | fixed |
| #70 | useReducedMotion initializes to false | assisted | fixed |
| #73 | isExternalHref regex duplicated | assisted | fixed |
| #76 | OG image not in JetBrains Mono | assisted | fixed |

## Notable changes

### `lib/github.ts`
- Surface GraphQL `errors` array (#56)
- Runtime shape guard on raw event elements (#57)
- Log keys-only on unexpected response shape (#61)

### `app/api/visitor/route.ts`
- Drop visitor email + IP from missing-key log (#62)

### `lib/useReducedMotion.ts`
- Rewrite with `useSyncExternalStore` to eliminate flash for reduced-motion users (#70)
- `SpotlightGrid` now consumes the shared hook (#66)

### `lib/contact.ts` (new)
- Single source of truth for `CONTACT_EMAIL`, `GITHUB_URL`, `GITHUB_HANDLE`, `LINKEDIN_URL`, `LINKEDIN_HANDLE` consumed by `CommandLayer`, `ContactObject`, `Terminal` (#67)

### `lib/projects.ts`
- New `isExternalHref(href)` helper consumed by `Work.tsx` and `ProjectCard.tsx` (#73)

### `components/Terminal.tsx`
- Extract `submitShell` helper (#64) and `TerminalPrompt` component (#65)
- `$` glyph now `aria-hidden`

### `components/Activity.tsx`
- `aria-hidden="true"` on decorative prefix glyphs (#38)

### `app/opengraph-image.tsx`
- Loads JetBrains Mono 400/500 from fontsource at render, caches 30d, falls back to generic monospace on fetch failure (#76)

### `app/error.tsx`
- Component renamed `GlobalError` → `RouteError` to reflect actual scope (#74)

### `app/sitemap.ts`
- Drop 4 anchor-only entries that crawlers ignore (#75)

### `package.json`
- Add modern `browserslist` to drop ~14 KiB of legacy-JS polyfills (#80)

### `components/GitGraph.tsx`
- Replace `as string` cast with explicit narrowing guard (#68)

## Needs human attention (not in this PR)

These were triaged as manual tier and skipped:
- **#69** — Terminal email gate collects PII without notice (legal/UX copy decision)
- **#71** — move runCommand to `lib/` (240-line refactor, scope creep risk)
- **#72** — JSON-LD ambiguous re: financial services (legal copy decision)
- **#81** — wrap GitGraph in `<Suspense>` (architectural — needs fallback UI design)

Plus the audit's offline flag: **FINRA Rule 3270 / Form U4 OBA disclosure** if Isaac is registered IAR/RR — talk to employer compliance.

## Gate status
- `npx tsc --noEmit` PASS
- `npm run lint` PASS
- `npm run build` PASS — sitemap/robots/og-image still prerendered

---
Generated by `/issue-bot` — review each commit individually before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)